### PR TITLE
Allow to configure throw on error in run_dakota

### DIFF
--- a/src/dakface.cpp
+++ b/src/dakface.cpp
@@ -62,21 +62,21 @@ using namespace Dakota;
   extern "C" void fpinit_ASL();
 #endif
 
-static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc);
+static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc, bool throw_on_error=false);
 
-int all_but_actual_main(int argc, char* argv[], void *exc)
+int all_but_actual_main(int argc, char* argv[], void *exc, bool throw_on_error=false)
 {
-  return _main(argc, argv, NULL, exc);
+  return _main(argc, argv, NULL, exc, throw_on_error);
 }
 
 #ifdef DAKOTA_HAVE_MPI
-int all_but_actual_main_mpi(int argc, char* argv[], MPI_Comm comm, void *exc)
+int all_but_actual_main_mpi(int argc, char* argv[], MPI_Comm comm, void *exc, bool throw_on_error=false)
 {
-  return _main(argc, argv, &comm, exc);
+  return _main(argc, argv, &comm, exc, trhow_on_error);
 }
 #endif
 
-static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc)
+static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc, bool throw_on_error)
 {
   static bool initialized = false;
   if (!initialized) 
@@ -90,9 +90,6 @@ static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc)
 
     // Tie signals to Dakota's abort_handler.
     // Dakota::register_signal_handlers();
-
-    // Have abort_handler() throw an exception rather than aborting the process.
-    // Dakota::abort_mode = Dakota::ABORT_THROWS;
 
     initialized = true;
   }
@@ -109,6 +106,10 @@ static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc)
 #else
   Dakota::ProgramOptions opts(argc, argv, 0);
 #endif
+
+  if(throw_on_error)
+     // Have Dakota throw an exception rather than aborting the process when error occurs
+     opts.exit_mode("throw");
 
   Dakota::LibraryEnvironment* env = 0;
   Dakota::data_pairs.clear();

--- a/src/dakface.hpp
+++ b/src/dakface.hpp
@@ -20,11 +20,12 @@
 
 using namespace Dakota;
 
-extern int all_but_actual_main(int argc, char* argv[], void *exc);
+extern int all_but_actual_main(int argc, char* argv[], void *exc, bool throw_on_error);
 
 #ifdef DAKOTA_HAVE_MPI
 extern int all_but_actual_main_mpi(int argc, char* argv[],
-                                   MPI_Comm comm, void *exc);
+                                   MPI_Comm comm, void *exc,
+                                   bool throw_on_error);
 #endif // DAKOTA_HAVE_MPI
 
 #endif // _DAKFACE_H_

--- a/src/dakota.py
+++ b/src/dakota.py
@@ -59,7 +59,7 @@ class DakotaBase(object):
 
         self.input = dakota_input
 
-    def run_dakota(self, infile='dakota.in', stdout=None, stderr=None, restart=0):
+    def run_dakota(self, infile='dakota.in', stdout=None, stderr=None, restart=0, throw_on_error=True):
         """
         This will create the configuration file for dakota,
         will set the driver instance that should handle dakota's requests and start dakota.
@@ -78,13 +78,14 @@ class DakotaBase(object):
         If a restart is required dakota expects a restart file to be present
         in the working directory with the name 'dakota.rst'
         :type restart: int
+        :param throw_on_error: Dakota throws on error instead of aborting
         """
 
         # Write dakota config file and set the driver_instance to self
         self.input.write_input(infile, driver_instance=self)
 
         # Run dakota
-        run_dakota(infile, stdout, stderr, restart=restart)
+        run_dakota(infile, stdout, stderr, restart=restart, throw_on_error=throw_on_error)
 
     def dakota_callback(self, **kwargs):
         """ Invoked from global :meth:`dakota_callback`, must be overridden. """
@@ -185,7 +186,7 @@ class _ExcInfo(object):
         self.traceback = None
 
 
-def run_dakota(infile, stdout=None, stderr=None, restart=0):
+def run_dakota(infile, stdout=None, stderr=None, restart=0, throw_on_error=True):
     """
     Run DAKOTA with the configuration file as provided as first argument 'infile'.
 
@@ -202,6 +203,7 @@ def run_dakota(infile, stdout=None, stderr=None, restart=0):
     If set to 1 than dakota will be started in restart mode. Dakota will
     expect in this case the restart file dakota.rst to be present in the working directory
     :type restart: int
+    :param throw_on_error: Dakota throws on error instead of aborting
     """
 
     # Checking for a Python exception via sys.exc_info() doesn't work, for
@@ -210,7 +212,12 @@ def run_dakota(infile, stdout=None, stderr=None, restart=0):
     # it with the exception information so we can re-raise it.
     err = 0
     exc = _ExcInfo()
-    err = carolina.run_dakota(infile, stdout, stderr, exc, restart)
+    err = carolina.run_dakota(infile,
+                              stdout,
+                              stderr,
+                              exc,
+                              restart,
+                              throw_on_error)
 
     # Check for errors. We'll get here if Dakota::abort_mode has been set to
     # throw an exception rather than shut down the process.

--- a/src/dakota_python_binding.cpp
+++ b/src/dakota_python_binding.cpp
@@ -46,7 +46,7 @@ namespace bpn = boost::python::numeric;
     argv[argc++] = errfile; \
   }
 
-int run_dakota(char *infile, char *outfile, char *errfile, bp::object exc, int restart)
+int run_dakota(char *infile, char *outfile, char *errfile, bp::object exc, int restart, bool throw_on_error)
 {
 
   MAKE_ARGV
@@ -59,11 +59,11 @@ int run_dakota(char *infile, char *outfile, char *errfile, bp::object exc, int r
   if (exc)
     tmp_exc = &exc;
 
-  return all_but_actual_main(argc, argv, tmp_exc);
+  return all_but_actual_main(argc, argv, tmp_exc, throw_on_error);
 }
 
 #ifdef DAKOTA_HAVE_MPI
-int run_dakota_mpi(char *infile, bp::object py_comm, char *outfile, char *errfile, bp::object exc, int restart)
+int run_dakota_mpi(char *infile, bp::object py_comm, char *outfile, char *errfile, bp::object exc, int restart, bool throw_on_error)
 {
   MPI_Comm comm = MPI_COMM_WORLD;
   if (py_comm) {
@@ -84,7 +84,7 @@ int run_dakota_mpi(char *infile, bp::object py_comm, char *outfile, char *errfil
   if (exc)
     tmp_exc = &exc;
 
-  return all_but_actual_main_mpi(argc, argv, comm, tmp_exc);
+  return all_but_actual_main_mpi(argc, argv, comm, tmp_exc, throw_on_error);
 }
 #endif
 


### PR DESCRIPTION
By default Dakota abort the application whenever an error occurs.
With this PR, an additional flag passed to `run_dakota` allows the user to choose whether the program should be aborted on error or if an exception should be thrown instead