### PR TITLE
Make sure Carolina extension is compiled with std=c++11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ def get_carolina_extension():
                          include_dirs=include_dirs,
                          define_macros=define_macros,
                          extra_link_args=['-Wl,-z origin'],
+                         extra_compile_args=['-std=c++11'],
                          library_dirs=library_dirs,
                          libraries=libraries,
                          language='c++')


### PR DESCRIPTION
When building Carolina on CentOS 6 the compiler complained that the c++ standard is not properly set.
This commit makes sure that the extension will have the compile argument set to c++11
 