### PR TITLE
Fix bug that removed fields from exception objects

### DIFF
--- a/src/dakface.cpp
+++ b/src/dakface.cpp
@@ -140,9 +140,9 @@ static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc, bool throw_
       PyObject *type = NULL, *value = NULL, *traceback = NULL;
       PyErr_Fetch(&type, &value, &traceback);
       bp::object *tmp = (bp::object *)exc;
-      PyObject_SetAttrString(tmp->ptr(), "type", type);
-      PyObject_SetAttrString(tmp->ptr(), "value", value);
-      PyObject_SetAttrString(tmp->ptr(), "traceback", traceback);
+      PyObject_SetAttrString(tmp->ptr(), "type", type ? type : Py_None);
+      PyObject_SetAttrString(tmp->ptr(), "value", value ? value : Py_None);
+      PyObject_SetAttrString(tmp->ptr(), "traceback", traceback ? traceback : Py_None);
     }
   }
 


### PR DESCRIPTION
Calling `PyObject_SetAttrString(obj, 'field', nullptr)` actually deletes `field` from `obj` (and that is clearly an issue if there is some exception handling code in python that expects that field to exist)
What we really want is setting the field to `None` instead