### PR TITLE
Fix #17: Make Carolina boost 1.65+ ready - making Python3 ready

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ RHEL 6.4 and Ubuntu 'pangolin'.
 """
 
 import os
+import glob
 import subprocess
 import sys
 import unittest
@@ -128,9 +129,13 @@ def get_carolina_extension():
 
 
     sources = ['src/dakface.cpp', 'src/dakota_python_binding.cpp']
-
+    
+    boost_python = 'boost_python'
+    if boost_lib:
+        boost_python = os.path.basename(glob.glob(os.path.join(boost_lib,"libboost_python*.so"))[0])[3:-3]
+    
     external_libs = ['boost_regex', 'boost_filesystem', 'boost_serialization',
-                     'boost_system', 'boost_signals', 'boost_python']
+                     'boost_system', 'boost_signals', boost_python]
 
     dakota_libs = get_dakota_libs(dakota_macros)
     libraries = dakota_libs + external_libs

--- a/src/dakota_python_binding.cpp
+++ b/src/dakota_python_binding.cpp
@@ -30,7 +30,12 @@ static void sayhello(MPI_Comm comm)
 #include "dakface.hpp"
 #include <boost/python.hpp>
 namespace bp = boost::python;
+
+#if BOOST_VERSION < 106500
 namespace bpn = boost::python::numeric;
+#endif
+
+
 
 #define MAKE_ARGV \
   char *argv[10]; \
@@ -103,7 +108,10 @@ void translator(const int& exc)
 using namespace boost::python;
 BOOST_PYTHON_MODULE(carolina)
 {
+
+#if BOOST_VERSION < 106500
   using namespace bpn;
+#endif
 
 #ifdef DAKOTA_HAVE_MPI
   if (import_mpi4py() < 0) return;
@@ -114,7 +122,10 @@ BOOST_PYTHON_MODULE(carolina)
 #else
   import_array();
 #endif
+
+#if BOOST_VERSION < 106500
   array::set_module_and_type("numpy", "ndarray");
+#endif
 
   register_exception_translator<int>(&translator);
 


### PR DESCRIPTION
Starting with version 1.65 Boost removes numeric namespace and uses numpy instead.
Made Carolina able to work with both numeric.

Building Boost 1.68 with Python 3.7 creates libboost_python37.so and setup.py would not have found it.
Setup.py searches for the exact libboost_python library.  