### PR TITLE
Fix incorrect BOOST_PYTHON default when using Py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,13 @@ if not DAKOTA_EXEC:
     exit('Unable to find dakota executable.')
 
 
+def get_default_boost_python():
+    if sys.version_info < (3,):
+        return "boost_python"
+    else:
+        return "boost_python3"
+
+
 def get_numpy_include():
     """Return path to numpy/core/include."""
     return os.path.join(os.path.dirname(numpy.__file__),
@@ -104,7 +111,7 @@ def get_boost_inc_lib():
         boost_inc_dir = os.path.join(boost_root, 'include')
         boost_lib_dir = os.path.join(boost_root, 'lib')
 
-    boost_python = os.getenv('BOOST_PYTHON', 'boost_python')
+    boost_python = os.getenv('BOOST_PYTHON', get_default_boost_python())
 
     if not boost_lib_dir:
         return boost_inc_dir, None, None, boost_python


### PR DESCRIPTION
Boost provides a `libboost_python3.so` for Python 3, but the `setup.py` wants to link with `boost_python` by default. The fix checks if we're using Python 3, and link with `boost_python3` if we are, by default.