### PR TITLE
Update documentation and resolve small cpp typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Carolina is a [pyDAKOTA](https://github.com/wisdem/pyDAKOTA) fork maintained by 
 
 ## Installation
 
-Python version: Carolina supports Python version 3.6, 3.7, 3.8.
+Python version: Carolina supports Python version 3.6, 3.7, 3.8, 3.10
 
 In order to build Carolina, [Boost](https://www.boost.org/), including Boost.Python, and [Dakota](https://dakota.sandia.gov/) must be installed. This requires [CMake](https://cmake.org/) and a C/C++ compiler.
 

--- a/src/dakface.cpp
+++ b/src/dakface.cpp
@@ -72,7 +72,7 @@ int all_but_actual_main(int argc, char* argv[], void *exc, bool throw_on_error=f
 #ifdef DAKOTA_HAVE_MPI
 int all_but_actual_main_mpi(int argc, char* argv[], MPI_Comm comm, void *exc, bool throw_on_error=false)
 {
-  return _main(argc, argv, &comm, exc, trhow_on_error);
+  return _main(argc, argv, &comm, exc, throw_on_error);
 }
 #endif
 


### PR DESCRIPTION
The README misleadingly state that Carolina runs on 3.6-3.8, while most use 3.10 (including PR-runner)
There is also an obvious c++ error that has been laying around for a while due to pragmas.