### PR TITLE
Update build to use C++17

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,7 @@ jobs:
         mkdir build
         cd build
         cmake \
+          -DCMAKE_CXX_STANDARD=14 \
           -DBUILD_SHARED_LIBS=ON \
           -DDAKOTA_PYTHON_DIRECT_INTERFACE=ON \
           -DDAKOTA_PYTHON_DIRECT_INTERFACE_NUMPY=ON \

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def get_carolina_extension():
                          include_dirs=include_dirs,
                          define_macros=define_macros,
                          extra_link_args=extra_link_args,
-                         extra_compile_args=['-std=c++11'],
+                         extra_compile_args=['-std=c++17'],
                          library_dirs=library_dirs,
                          libraries=libraries,
                          language='c++')


### PR DESCRIPTION
Update Carolina build to use the C++17 standard.
Update Dakota to be built with C+14.