### PR TITLE
Require Dakota 6.18 for Carolina

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,9 +100,6 @@ jobs:
       run: |
         export PATH=${PATH}:${HOME}/local/bin
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/local/lib
-        git apply dakota-6.13.patch
-        git apply dakota-6.16.patch
-        git apply dakota-6.18.patch
         python -m pip install .
     - name: Run Tests
       run: |

--- a/README.md
+++ b/README.md
@@ -30,33 +30,9 @@ The library can then be tested by entering the tests directory and execute:
     pytest
 ```
 
-### Installation for Dakota version 6.13 or above
+Carolina requires Dakota 6.18, but will work with older versions as well.
+Pathes can be reverted to allow for building against versions prior to 6.13 or 6.16.
 
-From Dakota version 6.13 a different set of boost libraries is needed: instead of `boost_signals`, `boost_program_options` is used. The Carolina setup script has not yet been updated to detect the Dakota version and use the correct library. Until then, apply the following patch to use Carolina with Dakota 6.13 and above:
-
-```bash
-    git apply dakota-6.13.patch
-```
-
-### Installation for Dakota version 6.16 or above
-
-From Dakota version 6.16 a small change was made in the Python interface. To
-support this, apply the following patches to use Carolina with Dakota 6.16 and
-above:
-
-```bash
-    git apply dakota-6.13.patch
-    git apply dakota-6.16.patch
-```
-
-### Installation for Dakota version 6.18 or above
-
+From Dakota version 6.13 a different set of boost libraries is needed: instead of `boost_signals`, `boost_program_options` is used.
+From Dakota version 6.16 a small change was made in the Python interface.
 From Dakota version 6.18 a file was removed from the source and build script was altered.
-To support this, apply the following patches to use Carolina with Dakota 6.18 and
-above:
-
-```bash
-    git apply dakota-6.13.patch
-    git apply dakota-6.16.patch
-    git apply dakota-6.18.patch
-```

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,11 @@ def find_dakota_paths():
     dakota_bin = os.path.join(dakota_install, 'bin')
     dakota_include = os.path.join(dakota_install, 'include')
     dakota_lib = os.path.join(dakota_install, 'lib')
+    eigen_include = os.path.join(dakota_include, 'eigen3')
     req = (dakota_bin, dakota_include, dakota_lib)
     if not all(map(os.path.exists, req)):
         exit("Can't find %s or %s or %s, bummer" % req)
-    return dakota_install, dakota_bin, dakota_include, dakota_lib
+    return dakota_install, dakota_bin, dakota_include, dakota_lib, eigen_include
 
 
 def read_dakota_macros(install_path):
@@ -115,10 +116,10 @@ def get_boost_inc_lib():
 
 def get_macros_include_library():
     """Get the dakota macros, include and library dirs."""
-    dakota_install, dakota_bin, dakota_include, dakota_lib = find_dakota_paths()
+    dakota_install, dakota_bin, dakota_include, dakota_lib, eigen_include = find_dakota_paths()
     dakota_macros = read_dakota_macros(dakota_install)
 
-    inc = [dakota_include, get_numpy_include()]
+    inc = [dakota_include, eigen_include, get_numpy_include()]
     lib = [dakota_lib, dakota_bin]
     return dakota_macros, inc, lib
 
@@ -141,7 +142,7 @@ def get_carolina_extension():
     
      
     external_libs = ['boost_regex', 'boost_filesystem', 'boost_serialization',
-                     'boost_system', 'boost_signals', boost_python]
+                     'boost_system', 'boost_program_options', boost_python]
 
     print(boost_python)
 

--- a/src/dakface.cpp
+++ b/src/dakface.cpp
@@ -32,7 +32,6 @@ namespace mpi = boost::mpi;
 
 #include <iostream>
 
-#include "dakota_windows.h"
 #include "dakota_system_defs.hpp"
 #include "ProgramOptions.hpp"
 #include "LibraryEnvironment.hpp"

--- a/src/dakota.py
+++ b/src/dakota.py
@@ -225,7 +225,7 @@ def run_dakota(infile, stdout=None, stderr=None, restart=0, throw_on_error=True)
             raise exc.type(exc.value).with_traceback(exc.traceback)
 
 
-def dakota_callback(**kwargs):
+def dakota_callback(kwargs):
     """
     Generic callback from DAKOTA, forwards parameters to driver provided as
     the ``driver_instance`` argument to :meth:`DakotaInput.write`.


### PR DESCRIPTION
Update repo with patch contents, and remove patching from process.

Relates to https://github.com/equinor/everest/issues/1864
