### PR TITLE
Remove unused MPI support

### DIFF
--- a/src/dakface.cpp
+++ b/src/dakface.cpp
@@ -24,12 +24,6 @@
 // Replaces Python.h according to boost_python docs.
 #include <boost/python/detail/wrap_python.hpp>
 
-#ifdef DAKOTA_HAVE_MPI
-#include <boost/mpi/environment.hpp>
-#include <boost/mpi/communicator.hpp>
-namespace mpi = boost::mpi;
-#endif
-
 #include <iostream>
 
 #include "dakota_system_defs.hpp"
@@ -68,13 +62,6 @@ int all_but_actual_main(int argc, char* argv[], void *exc, bool throw_on_error=f
   return _main(argc, argv, NULL, exc, throw_on_error);
 }
 
-#ifdef DAKOTA_HAVE_MPI
-int all_but_actual_main_mpi(int argc, char* argv[], MPI_Comm comm, void *exc, bool throw_on_error=false)
-{
-  return _main(argc, argv, &comm, exc, throw_on_error);
-}
-#endif
-
 static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc, bool throw_on_error)
 {
   static bool initialized = false;
@@ -97,14 +84,7 @@ static int _main(int argc, char* argv[], MPI_Comm *pcomm, void *exc, bool throw_
   // input data checks.  Assumes comm rank 0.
   //Dakota::ProgramOptions opts(argc, argv, 0);
   //Dakota::ParallelLibrary(argc, argv);
-#ifdef DAKOTA_HAVE_MPI
-  int rank;
-  // int ok;
-  // ok = MPI_Comm_rank( *pcomm, &rank ) ;
-  Dakota::ProgramOptions opts(argc, argv, rank);
-#else
   Dakota::ProgramOptions opts(argc, argv, 0);
-#endif
 
   if(throw_on_error)
      // Have Dakota throw an exception rather than aborting the process when error occurs

--- a/src/dakface.hpp
+++ b/src/dakface.hpp
@@ -22,10 +22,4 @@ using namespace Dakota;
 
 extern int all_but_actual_main(int argc, char* argv[], void *exc, bool throw_on_error);
 
-#ifdef DAKOTA_HAVE_MPI
-extern int all_but_actual_main_mpi(int argc, char* argv[],
-                                   MPI_Comm comm, void *exc,
-                                   bool throw_on_error);
-#endif // DAKOTA_HAVE_MPI
-
 #endif // _DAKFACE_H_


### PR DESCRIPTION
As done in PR https://github.com/equinor/Carolina/pull/33
MPI support have not been used for many years (guaranteed by compile error found in  https://github.com/equinor/Carolina/commit/fdbb6a1b6263b1cb9cc93eff74b48c9ab17429bb)

The syntax failure was introduced July 2018 and was fixed June 2023.
