### PR TITLE
Remove git describe call from macos wf

### DIFF
--- a/.github/workflows/bundle_with_dakota_macos.yml
+++ b/.github/workflows/bundle_with_dakota_macos.yml
@@ -197,9 +197,6 @@ jobs:
         echo "Pip list ...... "
         pip list | grep carolina
 
-        echo "Git desribe ...... "
-        git describe
-
         echo $carolina_so_path
         otool -l $carolina_so_path
         echo "Finding missing dylibs"


### PR DESCRIPTION
Fixes err w tags, ref: https://github.com/equinor/Carolina/actions/runs/6979535230/job/18993019201  🪄

Run wheel build&publish on MacOS currently gives:
```
Git desribe ...... 
fatal: No annotated tags can describe '64d469e7d5fad67716fe004c520cac78e658ca46'.
```
Can just remove the `git describe` call